### PR TITLE
Small fix in Shavitt's method for Boys function evaluation

### DIFF
--- a/doc/kernel_boys.dox
+++ b/doc/kernel_boys.dox
@@ -77,7 +77,7 @@ Since it guaranteed that the true error is less than this value, it can then det
 If it is not, then the small-\f$t\f$ (exact) formulation is used:
 
 \f{eqnarray*}{
-   F_m(t) &=& e^{-t} \frac{1}{2^{m+1}} \sum_{i=1}^{\infty} a_i \\
+   F_m(t) &=& e^{-t} \frac{1}{2m+1} \sum_{i=1}^{\infty} a_i \\
    a_0 &=& 1 \\
    a_i &=& \frac{2t}{2m+2i+1}a_{i-1}
 \f}


### PR DESCRIPTION
Looking through your documentation, I noticed what appears to be a small typo:

<img width="211" height="122" alt="image" src="https://github.com/user-attachments/assets/2ff8691c-844f-4da0-b104-f587ff4e6272" />

The denominator `2^(m+1)` should be `(2m+1)`. The implementation in the code itself appears to be correct.

Hope this helps, and thanks for your work on this.